### PR TITLE
Allow hooking into VBR calls

### DIFF
--- a/post.js
+++ b/post.js
@@ -29,6 +29,21 @@ return {
 
 	set_bitrate: Module.cwrap('lame_set_brate', 'number', [ 'number', 'number' ]),
 	get_bitrate: Module.cwrap('lame_get_brate', 'number', [ 'number' ]),
+	
+	set_VBR: Module.cwrap('lame_set_VBR', 'number', [ 'number', 'number' ]),
+	get_VBR: Module.cwrap('lame_get_VBR', 'number', [ 'number' ]),
+	
+	set_VBR_q: Module.cwrap('lame_set_VBR_q', 'number', [ 'number', 'number' ]),
+	get_VBR_q: Module.cwrap('lame_get_VBR_q', 'number', [ 'number' ]),
+	
+	set_VBR_mean_bitrate_kbps: Module.cwrap('lame_set_VBR_mean_bitrate_kbps', 'number', [ 'number', 'number' ]),
+	get_VBR_mean_bitrate_kbps: Module.cwrap('lame_get_VBR_mean_bitrate_kbps', 'number', [ 'number' ]),
+	
+	set_VBR_min_bitrate_kbps: Module.cwrap('lame_set_VBR_min_bitrate_kbps', 'number', [ 'number', 'number' ]),
+	get_VBR_min_bitrate_kbps: Module.cwrap('lame_get_VBR_min_bitrate_kbps', 'number', [ 'number' ]),
+	
+	set_VBR_max_bitrate_kbps: Module.cwrap('lame_set_VBR_max_bitrate_kbps', 'number', [ 'number', 'number' ]),
+	get_VBR_max_bitrate_kbps: Module.cwrap('lame_get_VBR_max_bitrate_kbps', 'number', [ 'number' ]),
 
 	encode_buffer_ieee_float: function(handle, channel_l, channel_r) {
 		var outbuf = _malloc(BUFSIZE);
@@ -64,4 +79,7 @@ return {
 };
 
 })();
+
+self.Lame = Lame; // make Lame accessible to other webworker scripts.
+
 


### PR DESCRIPTION
I'm kinda shooting in the dark here, but I tried this on my local copy and it worked well. Please pull this if it seems correct.

Also added `self` call at the end since I needed to do that to expose Lame to other webworkers.

See my fork of your webworker here (that uses VBR):
https://github.com/chaoscollective/chaos-lib-client/blob/master/jsworkers/lame/encoder.js

There's also a compressed version of the javascript with changes incorporated in the parent folder if that's helpful.

I'm getting nice sounding (and well compressed files) for these settings:

```
    encoder.postMessage({
      cmd: 'init',
      config: {
        in_samplerate:  44100,
        out_samplerate: 44100,
        bitrate: 64, // doesn't matter with VBR
        channels: 1,
        vbr: 2,
        vbr_min: 4, // min kbps
        vbr_max: 128, // max kbps
        vbr_q: 9 // quality of 9 gives both small files and good quality.
      }
    });
```
